### PR TITLE
Exposing DBAL objects for fine-grained control

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     }
 }

--- a/src/FluidColumn.php
+++ b/src/FluidColumn.php
@@ -244,4 +244,13 @@ class FluidColumn
     {
         return new FluidColumnOptions($this->fluidTable, $this->column, $this->namingStrategy);
     }
+
+    /**
+     * Returns the underlying DBAL column.
+     * @return Column
+     */
+    public function getDbalColumn(): Column
+    {
+        return $this->column;
+    }
 }

--- a/src/FluidTable.php
+++ b/src/FluidTable.php
@@ -130,4 +130,13 @@ class FluidTable
         $this->column($pk->getName())->references($tableName)->primaryKey();
         return $this;
     }
+
+    /**
+     * Returns the underlying DBAL table.
+     * @return Table
+     */
+    public function getDbalTable(): Table
+    {
+        return $this->table;
+    }
 }

--- a/tests/FluidColumnTest.php
+++ b/tests/FluidColumnTest.php
@@ -97,6 +97,9 @@ class FluidColumnTest extends TestCase
             $column->datetimeTzImmutable();
             $this->assertSame(Type::getType(Type::DATETIMETZ_IMMUTABLE), $dbalColumn->getType());
 
+            $column->time();
+            $this->assertSame(Type::getType(Type::TIME), $dbalColumn->getType());
+
             $column->timeImmutable();
             $this->assertSame(Type::getType(Type::TIME_IMMUTABLE), $dbalColumn->getType());
 
@@ -106,6 +109,8 @@ class FluidColumnTest extends TestCase
             $column->json();
             $this->assertSame(Type::getType(Type::JSON), $dbalColumn->getType());
         }
+
+        $this->assertSame('foo', $column->getDbalColumn()->getName());
     }
 
     public function testReference()

--- a/tests/FluidSchemaTest.php
+++ b/tests/FluidSchemaTest.php
@@ -44,4 +44,12 @@ class FluidSchemaTest extends TestCase
         $this->assertNotNull($schema->getTable('users_roles')->getColumn('user_id'));
         $this->assertNotNull($schema->getTable('users_roles')->getColumn('role_id'));
     }
+
+    public function testGetDbalSchema()
+    {
+        $schema = new Schema();
+        $fluid = new FluidSchema($schema);
+
+        $this->assertSame($schema, $fluid->getDbalSchema());
+    }
 }

--- a/tests/FluidTableTest.php
+++ b/tests/FluidTableTest.php
@@ -137,11 +137,14 @@ class FluidTableTest extends TestCase
         $this->assertSame(['id'], $fk->getLocalColumns());
     }
 
-    public function testGetDbalSchema()
+    public function testGetDbalTable()
     {
         $schema = new Schema();
         $fluid = new FluidSchema($schema);
 
-        $this->assertSame($schema, $fluid->getDbalSchema());
+        $contacts = $fluid->table('contacts');
+        $this->assertSame('contacts', $contacts->getDbalTable()->getName());
     }
+
+
 }

--- a/tests/FluidTableTest.php
+++ b/tests/FluidTableTest.php
@@ -145,6 +145,4 @@ class FluidTableTest extends TestCase
         $contacts = $fluid->table('contacts');
         $this->assertSame('contacts', $contacts->getDbalTable()->getName());
     }
-
-
 }


### PR DESCRIPTION
This PR adds 2 new method:

- FluidTable::getDbalTable()
- FluidColumn::getDbalColumn()

These methods are exposing the underlying DBAL API for fin grained control.